### PR TITLE
Make it compatible with -std=C89

### DIFF
--- a/source/tinycthread.c
+++ b/source/tinycthread.c
@@ -547,7 +547,7 @@ int thrd_sleep(const struct timespec *time_point, struct timespec *remaining)
 
   /* Get the current time */
   if (clock_gettime(TIME_UTC, &now) != 0)
-    return -2;  // FIXME: Some specific error code?
+    return -2;  /* FIXME: Some specific error code? */
 
 #if defined(_TTHREAD_WIN32_)
   /* Delta in milliseconds */


### PR DESCRIPTION
I compiled this lib using -std=c89 under GCC, it generated a warning, and I found it's the only line of comments that using '//'. 
