### PR TITLE
Use _Noreturn if __STDC_VERSION__ indicates C11 support.

### DIFF
--- a/source/tinycthread.h
+++ b/source/tinycthread.h
@@ -97,7 +97,9 @@ extern "C" {
 #endif
 
 /* Compiler-specific information */
-#if defined(__GNUC__)
+#if __STDC_VERSION__ >= 201112L
+  #define TTHREAD_NORETURN _Noreturn
+#elif defined(__GNUC__)
   #define TTHREAD_NORETURN __attribute__((noreturn))
 #else
   #define TTHREAD_NORETURN
@@ -360,7 +362,7 @@ int thrd_equal(thrd_t thr0, thrd_t thr1);
 /** Terminate execution of the calling thread.
 * @param res Result code of the calling thread.
 */
-void thrd_exit(int res) TTHREAD_NORETURN;
+TTHREAD_NORETURN void thrd_exit(int res);
 
 /** Wait for a thread to terminate.
 * The function joins the given thread with the current thread by blocking


### PR DESCRIPTION
Previously, TTHREAD_NORETURN was **attribute**((noreturn)) or nothing.
There are two reasons why this is desirable:

1) Works for compilers without GNU extension support.
2) If <stdnoreturn.h> (also part of C11) is included before
tinycthread.h, noreturn is defined as _Noreturn, so
__attribute__((noreturn)) expands to **attribute**((_Noreturn)) and
breaks.  An alternative fix is switching to __attribute__((**noreturn**)),
but may as well use the standard version.
