### PR TITLE
cnd_broadcast() should use pthread_cond_broadcast()

### DIFF
--- a/source/tinycthread.c
+++ b/source/tinycthread.c
@@ -378,7 +378,7 @@ int cnd_broadcast(cnd_t *cond)
 
   return thrd_success;
 #else
-  return pthread_cond_signal(cond) == 0 ? thrd_success : thrd_error;
+  return pthread_cond_broadcast(cond) == 0 ? thrd_success : thrd_error;
 #endif
 }
 


### PR DESCRIPTION
Currently, it calls pthread_cond_signal(), which explains why only one of my job manager threads was waking up when I tried to shut it down :)
