### PR TITLE
VC2013 warning removal

### DIFF
--- a/source/tinycthread.c
+++ b/source/tinycthread.c
@@ -151,7 +151,7 @@ int mtx_timedlock(mtx_t *mtx, const struct timespec *ts)
   }
   else
   {
-    timeoutMs  = (ts->tv_sec  - current_ts.tv_sec)  * 1000;
+    timeoutMs  = (DWORD)(ts->tv_sec  - current_ts.tv_sec)  * 1000;
     timeoutMs += (ts->tv_nsec - current_ts.tv_nsec) / 1000000;
     timeoutMs += 1;
   }
@@ -446,8 +446,8 @@ int cnd_timedwait(cnd_t *cond, mtx_t *mtx, const struct timespec *ts)
   struct timespec now;
   if (timespec_get(&now, TIME_UTC) == 0)
   {
-    DWORD delta = (ts->tv_sec - now.tv_sec) * 1000 +
-                  (ts->tv_nsec - now.tv_nsec + 500000) / 1000000;
+    DWORD delta = (DWORD)((ts->tv_sec - now.tv_sec) * 1000 +
+                  (ts->tv_nsec - now.tv_nsec + 500000) / 1000000);
     return _cnd_timedwait_win32(cond, mtx, delta);
   }
   else
@@ -701,9 +701,9 @@ int thrd_sleep(const struct timespec *duration, struct timespec *remaining)
 
   timespec_get(&start, TIME_UTC);
 
-  t = SleepEx(duration->tv_sec * 1000 +
+  t = SleepEx((DWORD)(duration->tv_sec * 1000 +
               duration->tv_nsec / 1000000 +
-              (((duration->tv_nsec % 1000000) == 0) ? 0 : 1),
+              (((duration->tv_nsec % 1000000) == 0) ? 0 : 1)),
               TRUE);
 
   if (t == 0) {
@@ -861,7 +861,7 @@ int _tthread_timespec_get(struct timespec *ts, int base)
   }
 
 #if defined(_TTHREAD_WIN32_)
-  _ftime(&tb);
+  _ftime64_s(&tb);
   ts->tv_sec = (time_t)tb.time;
   ts->tv_nsec = 1000000L * (long)tb.millitm;
 #elif defined(CLOCK_REALTIME)


### PR DESCRIPTION
Visual C++ uses time_t as 64 bits and generates warnings.
I have made simple changes and cast then, A most solid solution could remove all DWORD and use the proper type compatible in size with time_t.
http://msdn.microsoft.com/query/dev12.query?appId=Dev12IDEF1&l=EN-US&k=k(timeb%2F_ftime64_s);k(_ftime64_s);k(DevLang-C%2B%2B);k(TargetOS-Windows)&rd=true
There is also a MACRO in windows, _USE_32BIT_TIME_T that if defined makes time_t 32 bits.

Also changed from _ftime(&tb);   to _ftime64_s(&tb);

