### PR TITLE
Fix for missing _ftime_s on MinGW

### DIFF
--- a/source/tinycthread.h
+++ b/source/tinycthread.h
@@ -94,6 +94,10 @@ extern "C" {
     #undef WIN32_LEAN_AND_MEAN
     #undef __UNDEF_LEAN_AND_MEAN
   #endif
+  #ifdef __MINGW32__
+    // MinGW has no _ftime_s symbol
+    #define _ftime_s _ftime
+  #endif
 #endif
 
 /* Compiler-specific information */


### PR DESCRIPTION
As detailed in http://lists.freedesktop.org/archives/spice-devel/2012-February/007608.html

> mingw has a _ftime_s prototype in its headers, but no corresponding
> symbol available at link time. Workaround this issue for now by
> #defining it to _ftime

This is also a confirmed bug in x64 using MinGW.