### PR TITLE
miscellaneous fixes

### DIFF
--- a/source/tinycthread.h
+++ b/source/tinycthread.h
@@ -329,6 +329,7 @@ typedef int (*thrd_start_t)(void *arg);
 
 /** Create a new thread.
 * @param thr Identifier of the newly created thread.
+* @param stacksize The initial size of the stack, in bytes.
 * @param func A function pointer to the function that will be executed in
 *        the new thread.
 * @param arg An argument to the thread function.
@@ -339,7 +340,7 @@ typedef int (*thrd_start_t)(void *arg);
 * original thread has exited and either been detached or joined to another
 * thread.
 */
-int thrd_create(thrd_t *thr, thrd_start_t func, void *arg);
+int thrd_create(thrd_t *thr, int stacksize, thrd_start_t func, void *arg);
 
 /** Identify the calling thread.
 * @return The identifier of the calling thread.


### PR DESCRIPTION
- added option to set the initial size of the stack
- not all POSIX implementations create threads as joinable by default
- windows thread handles 'cannot' be compared; because for ex.
GetCurrentThread() returns a pseudo handle