### PR TITLE
Improve compatibility with C11 std

### DIFF
--- a/source/tinycthread.h
+++ b/source/tinycthread.h
@@ -166,6 +166,8 @@ int _tthread_timespec_get(struct timespec *ts, int base);
  #define _Thread_local __thread
 #endif
 
+#define thread_local _Thread_local
+
 /* Macros */
 #if defined(_TTHREAD_WIN32_)
 #define TSS_DTOR_ITERATIONS (4)
@@ -174,16 +176,22 @@ int _tthread_timespec_get(struct timespec *ts, int base);
 #endif
 
 /* Function return values */
-#define thrd_error    0 /**< The requested operation failed */
-#define thrd_success  1 /**< The requested operation succeeded */
-#define thrd_timedout 2 /**< The time specified in the call was reached without acquiring the requested resource */
-#define thrd_busy     3 /**< The requested operation failed because a tesource requested by a test and return function is already in use */
-#define thrd_nomem    4 /**< The requested operation failed because it was unable to allocate memory */
+enum
+{
+  thrd_success  = 0, /**< The requested operation succeeded */
+  thrd_busy     = 1, /**< The requested operation failed because a resource requested by a test and return function is already in use */
+  thrd_error    = 2, /**< The requested operation failed */
+  thrd_nomem    = 3, /**< The requested operation failed because it was unable to allocate memory */
+  thrd_timedout = 4  /**< The time specified in the call was reached without acquiring the requested resource */
+};
 
 /* Mutex types */
-#define mtx_plain     0
-#define mtx_timed     1
-#define mtx_recursive 2
+enum
+{
+  mtx_plain     = 0,
+  mtx_recursive = 1,
+  mtx_timed     = 2
+};
 
 /* Mutex */
 #if defined(_TTHREAD_WIN32_)


### PR DESCRIPTION
- According to C11, the thrd_X and mtx_X constants should be enum types: http://www.open-std.org/JTC1/SC22/WG14/www/docs/n1570.pdf#page=394
I also reordered them, according to native threads.h-file on Ubuntu Linux.
- Further, thread_local macro was not defined, also added this.