### PR TITLE
Fix compilation on Mingw-w64

### DIFF
--- a/source/tinycthread.h
+++ b/source/tinycthread.h
@@ -97,8 +97,8 @@ extern "C" {
     #undef WIN32_LEAN_AND_MEAN
     #undef __UNDEF_LEAN_AND_MEAN
   #endif
-  #ifdef __MINGW32__
-    /* MinGW has no _ftime_s symbol */
+  #if defined (__MINGW32__) && !defined(__MINGW64__)
+    /* Older versions of MinGW have no _ftime_s symbol */
     #define _ftime_s _ftime
   #endif
 #endif


### PR DESCRIPTION
Mingw-w64 already has _ftime_s defined, this will avoid duplicate definitions.