### PR TITLE
Use thread ID rather than a thread handle to identify threads on Windows

### DIFF
--- a/source/tinycthread.c
+++ b/source/tinycthread.c
@@ -588,6 +588,72 @@ static void * _thrd_wrapper_function(void * aArg)
 #endif
 }
 
+#if defined(_TTHREAD_WIN32_)
+struct TinyCThreadThrdData {
+    DWORD thread_id;
+    HANDLE handle;
+    struct TinyCThreadThrdData* next;
+};
+
+static struct TinyCThreadThrdData* _tinycthread_thread_head = NULL;
+
+static void _insert_thread_data(struct TinyCThreadThrdData* data)
+{
+  if (_tinycthread_thread_head == NULL)
+  {
+    _tinycthread_thread_head = data;
+  }
+  else
+  {
+    struct TinyCThreadThrdData* node = _tinycthread_thread_head;
+    while (node->next != NULL)
+    {
+       node = node->next;
+    }
+    node->next = data;
+  }
+}
+
+static struct TinyCThreadThrdData* _lookup_thread_handle(DWORD thread_id)
+{
+  struct TinyCThreadThrdData* node = _tinycthread_thread_head;
+  while (node != NULL)
+  {
+    if (node->thread_id == thread_id)
+    {
+      return node->handle;
+    }
+    node = node->next;
+  } 
+  return NULL;
+}
+
+static void _remove_thread_data(DWORD thread_id)
+{
+  struct TinyCThreadThrdData* node = _tinycthread_thread_head;
+  if (node != NULL)
+  {
+    if (node->thread_id == thread_id)
+    {
+      _tinycthread_thread_head = node->next;
+      free(node);
+      return;
+    }
+    while (node->next != NULL)
+    {
+      if (node->next->thread_id == thread_id)
+      {
+        struct TinyCThreadThrdData* needle = node->next;
+        node->next = needle->next;
+        free(needle);
+        return;
+      }
+      node = node->next;
+    }
+  }
+}
+#endif
+
 int thrd_create(thrd_t *thr, thrd_start_t func, void *arg)
 {
   /* Fill out the thread startup information (passed to the thread wrapper,
@@ -602,20 +668,32 @@ int thrd_create(thrd_t *thr, thrd_start_t func, void *arg)
 
   /* Create the thread */
 #if defined(_TTHREAD_WIN32_)
-  *thr = CreateThread(NULL, 0, _thrd_wrapper_function, (LPVOID) ti, 0, NULL);
+  struct TinyCThreadThrdData* data;
+  data = (struct TinyCThreadThrdData*)malloc(sizeof(struct TinyCThreadThrdData));
+  if (data == NULL)
+  {
+    free(ti);
+    return thrd_nomem;
+  }
+  HANDLE handle = CreateThread(NULL, 0, _thrd_wrapper_function, (LPVOID)ti, 0, NULL);
+  if (handle == NULL)
+  {
+    free(ti);
+    free(data);
+    return thrd_error;
+  }
+  data->handle = handle;
+  data->thread_id = GetThreadId(handle);
+  data->next = NULL;
+  _insert_thread_data(data);
+  *thr = data->thread_id;
 #elif defined(_TTHREAD_POSIX_)
   if(pthread_create(thr, NULL, _thrd_wrapper_function, (void *)ti) != 0)
   {
-    *thr = 0;
+      free(ti);
+      return thrd_error;
   }
 #endif
-
-  /* Did we fail to create the thread? */
-  if(!*thr)
-  {
-    free(ti);
-    return thrd_error;
-  }
 
   return thrd_success;
 }
@@ -623,7 +701,7 @@ int thrd_create(thrd_t *thr, thrd_start_t func, void *arg)
 thrd_t thrd_current(void)
 {
 #if defined(_TTHREAD_WIN32_)
-  return GetCurrentThread();
+  return GetCurrentThreadId();
 #else
   return pthread_self();
 #endif
@@ -633,7 +711,17 @@ int thrd_detach(thrd_t thr)
 {
 #if defined(_TTHREAD_WIN32_)
   /* https://stackoverflow.com/questions/12744324/how-to-detach-a-thread-on-windows-c#answer-12746081 */
-  return CloseHandle(thr) != 0 ? thrd_success : thrd_error;
+  HANDLE handle = _lookup_thread_handle(thr);
+  if (handle == NULL)
+  {
+    return thrd_error;
+  }
+  BOOL success = CloseHandle(handle);
+  if (success)
+  {
+      _remove_thread_data(thr);
+  }
+  return success ? thrd_success : thrd_error;
 #else
   return pthread_detach(thr) == 0 ? thrd_success : thrd_error;
 #endif
@@ -642,7 +730,7 @@ int thrd_detach(thrd_t thr)
 int thrd_equal(thrd_t thr0, thrd_t thr1)
 {
 #if defined(_TTHREAD_WIN32_)
-  return GetThreadId(thr0) == GetThreadId(thr1);
+  return thr0 == thr1;
 #else
   return pthread_equal(thr0, thr1);
 #endif
@@ -666,14 +754,18 @@ int thrd_join(thrd_t thr, int *res)
 {
 #if defined(_TTHREAD_WIN32_)
   DWORD dwRes;
-
-  if (WaitForSingleObject(thr, INFINITE) == WAIT_FAILED)
+  HANDLE handle = _lookup_thread_handle(thr);
+  if (handle == NULL)
+  {
+      return thrd_error;
+  }
+  if (WaitForSingleObject(handle, INFINITE) == WAIT_FAILED)
   {
     return thrd_error;
   }
   if (res != NULL)
   {
-    if (GetExitCodeThread(thr, &dwRes) != 0)
+    if (GetExitCodeThread(handle, &dwRes) != 0)
     {
       *res = (int) dwRes;
     }
@@ -682,7 +774,12 @@ int thrd_join(thrd_t thr, int *res)
       return thrd_error;
     }
   }
-  CloseHandle(thr);
+  BOOL success = CloseHandle(handle);
+  if (success)
+  {
+      _remove_thread_data(thr);
+  }
+  return success ? thrd_success : thrd_error;
 #elif defined(_TTHREAD_POSIX_)
   void *pres;
   if (pthread_join(thr, &pres) != 0)

--- a/source/tinycthread.h
+++ b/source/tinycthread.h
@@ -320,7 +320,7 @@ int cnd_timedwait(cnd_t *cond, mtx_t *mtx, const struct timespec *ts);
 
 /* Thread */
 #if defined(_TTHREAD_WIN32_)
-typedef HANDLE thrd_t;
+typedef DWORD thrd_t;
 #else
 typedef pthread_t thrd_t;
 #endif


### PR DESCRIPTION
Currently on Windows thrd_current() simply calls GetCurrentThread() which returns a pseudo handle that **always** refers to the current thread. This handle value is the same regardless of which thread called thrd_current(). If the identifier of the current thread needs to be saved and compared from another thread, this value becomes meaningless.

The below code saves the identifier of each thread to call do_it() into an array but as thrd_current() always returns 0xfffffffffffffffe it appears as if do_it() was called from the same thread 5 times rather than 5 separate, distinct threads.

```
#include "tinycthread.h"
#include <stdio.h>

#define THREAD_COUNT 5

int visit_count = 0;
thrd_t visited_by[THREAD_COUNT];
mtx_t mutex;

int do_it(void* arg)
{
	mtx_lock(&mutex);
	visited_by[visit_count] = thrd_current();
	visit_count++;
	mtx_unlock(&mutex);
	return 0;
}

int main()
{
	mtx_init(&mutex, mtx_plain);
	thrd_t threads[THREAD_COUNT];

	for (int i = 0; i < THREAD_COUNT; i++)
	{
		thrd_create(&threads[i], do_it, NULL);
	}
	for (int i = 0; i < THREAD_COUNT; i++)
	{
		thrd_join(threads[i], NULL);
	}
	for (int i = 0; i < THREAD_COUNT; i++)
	{
		printf("%p\n", visited_by[i]);
	}
}
```
```
FFFFFFFFFFFFFFFE
FFFFFFFFFFFFFFFE
FFFFFFFFFFFFFFFE
FFFFFFFFFFFFFFFE
FFFFFFFFFFFFFFFE
```

This pull request changes the definition of thrd_t from HANDLE to DWORD and uses the thread ID returned from GetThreadId() and GetCurrentThreadId() which is a unique thread identifier. A linked list is used to store the associations between the unique thread ID and HANDLE's created via thrd_create.

With the proposed changes, the above example now outputs something like below, with each returning a unique thread identifier via thrd_current() that matches the exact same identifier that was returned via thrd_create()

```
0000000000004F3C
000000000000085C
0000000000002504
000000000000286C
00000000000046D8
```